### PR TITLE
demote `failed to check for flutter-pi updates` to a warning

### DIFF
--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -129,7 +129,7 @@ class FlutterpiBinaries extends ArtifactSet {
           return false;
         }
       } on gh.GitHubError catch (e) {
-        logger.printError('Failed to check for flutter-pi updates: ${e.message}');
+        logger.printWarning('Failed to check for flutter-pi updates: ${e.message}');
         return true;
       }
     }


### PR DESCRIPTION
People assume the tool failed, but in reality everything works as expected.
