### PR TITLE
Update pubspec.yaml to Accept Higher Versions of http Package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   file: ">=6.1.4 <8.0.0"
   path: ^1.8.3
   args: ^2.4.0
-  http: ^0.13.6
+  http: ">=0.13.6 <1.2.3"
   meta: ^1.10.0
   process: ^5.0.0
   unified_analytics: ">=5.8.0 <7.0.0"


### PR DESCRIPTION
**This pull request addresses the issue of dependency version conflicts when installing flutterpi_tool on Ubuntu WSL2. The pubspec.yaml file has been updated to accept higher versions of the http package, preventing the error message encountered during installation.**


> Previously, this issue was only present in the beta and pre-release channels of Flutter. However, with the latest stable version, some dependencies have been pinned to higher versions, causing the same problem to occur.


**Steps to Reproduce the Issue:**
Set up flutter_pi on Raspberry Pi 3B.
Use Ubuntu WSL2 as the development environment.

**Attempt to install flutterpi_tool using the command:**
bash
dart pub global activate flutterpi_tool
**Expected Behavior:** flutterpi_tool should install without any dependency issues.

**Actual Behavior:** The installation fails due to dependency version conflicts. SOLVED BY THIS COMMIT

**Additional Information:**
- Flutter version: 3.27.0
- Dart version: 3.6.0
- Ubuntu version: 24.04.1 LTS (WSL2)

**Changes Made:**
- [ ] Updated pubspec.yaml to allow http package versions >=0.13.6 <1.2.3.
