### PR TITLE
Fix dependency issue that prevented the tool to be installed after Flutter 3.29

### DIFF
--- a/lib/src/build_system/build_app.dart
+++ b/lib/src/build_system/build_app.dart
@@ -101,7 +101,7 @@ Future<void> buildFlutterpiBundle({
     buildDir: project.dartTool.childDirectory('flutter_build'),
     cacheDir: globals.cache.getRoot(),
     flutterRootDir: globals.fs.directory(Cache.flutterRoot),
-    engineVersion: globals.artifacts!.isLocalEngine
+    engineVersion: globals.artifacts!.usesLocalArtifacts
         ? null
         : globals.flutterVersion.engineRevision,
     analytics: NoOpAnalytics(),

--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -1050,7 +1050,7 @@ class OverrideGenSnapshotArtifacts implements Artifacts {
       parent.getEngineType(platform, mode);
 
   @override
-  bool get isLocalEngine => parent.isLocalEngine;
+  bool get usesLocalArtifacts => parent.usesLocalArtifacts;
 
   @override
   FileSystemEntity getHostArtifact(HostArtifact artifact) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   http: ">=0.13.6 <2.0.0"
   meta: ^1.10.0
   process: ^5.0.0
-  unified_analytics: ">=5.8.0 <7.0.0"
+  unified_analytics: ^7.0.0
   archive: ^3.3.2
   crypto: ^3.0.3
 


### PR DESCRIPTION
One getter in `Artifacts` was renamed from `isLocalEngine` to `usesLocalArtifacts`. See here: https://github.com/flutter/flutter/commit/8b4d48715bddfdfbaa2bfcdd9950cd63d58d62db. The usage is the same.

Fixes #46