### PR TITLE
Flutter 3.29 compatibility

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           cache: true
           channel: stable
-          flutter-version: 3.27.x
+          flutter-version: 3.29.x
       
       - name: Install dependencies
         run: flutter pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutterpi_tool
 description: A tool to make development & distribution of flutter-pi apps easier.
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/ardera/flutterpi_tool
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/ardera/flutterpi_tool
 
 environment:
   sdk: ^3.0.5
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"
 
 executables:
   # TODO(ardera): Maybe add an alias `flutterpi-tool` here?

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -586,6 +586,7 @@ void main() {
         platform: platform,
         processManager: cacheProcessManager,
         artifacts: artifacts,
+        rootOverride: fs.directory("cache"),
       );
 
       binaries = FlutterpiBinaries(


### PR DESCRIPTION
- Use flutter 3.29 in CI.
- Depend on Flutter `>= 3.29` in pubspec.yaml
