### PR TITLE
feat: support tests & integration tests

### DIFF
--- a/lib/src/build_system/build_app.dart
+++ b/lib/src/build_system/build_app.dart
@@ -40,8 +40,16 @@ Future<FlutterpiAppBundle> buildFlutterpiApp({
     target: target,
     buildInfo: buildInfo,
     artifactPaths: artifactPaths,
-    outDir: outDir,
     operatingSystemUtils: operatingSystemUtils,
+    mainPath: mainPath,
+    manifestPath: manifestPath,
+    applicationKernelFilePath: applicationKernelFilePath,
+    depfilePath: depfilePath,
+    outDir: outDir,
+    artifacts: artifacts,
+    buildSystem: buildSystem,
+    unoptimized: unoptimized,
+    includeDebugSymbols: includeDebugSymbols,
   );
 
   return PrebuiltFlutterpiAppBundle(

--- a/lib/src/cli/command_runner.dart
+++ b/lib/src/cli/command_runner.dart
@@ -33,6 +33,14 @@ class FlutterpiToolCommandRunner extends CommandRunner<void>
           'Use this to select a specific version of the web sdk if you have built multiple engine targets.\n'
           'This path is relative to "--local-engine-src-path" (see above).',
     );
+
+    argParser.addFlag(
+      FlutterGlobalOptions.kPrintDtd,
+      negatable: false,
+      help:
+          'Print the address of the Dart Tooling Daemon, if one is hosted by the Flutter CLI.',
+      hide: !verboseHelp,
+    );
   }
 
   @override

--- a/lib/src/cli/commands/devices.dart
+++ b/lib/src/cli/commands/devices.dart
@@ -409,6 +409,7 @@ class DevicesAddCommand extends FlutterpiCommand {
     );
 
     usesDisplaySizeArg();
+    usesDummyDisplayArg();
     usesSshRemoteNonOptionArg();
   }
 
@@ -494,6 +495,8 @@ class DevicesAddCommand extends FlutterpiCommand {
         sshRemote: remote,
         remoteInstallPath: remoteInstallPath,
         displaySizeMillimeters: displaySize,
+        useDummyDisplay: useDummyDisplay,
+        dummyDisplaySize: dummyDisplaySize,
       ),
     );
 

--- a/lib/src/cli/commands/test.dart
+++ b/lib/src/cli/commands/test.dart
@@ -1,0 +1,8 @@
+import 'package:flutterpi_tool/src/cli/flutterpi_command.dart';
+import 'package:flutterpi_tool/src/fltool/common.dart' as fltool;
+
+class TestCommand extends fltool.TestCommand with FlutterpiCommandMixin {
+  TestCommand() {
+    usesDeviceManager();
+  }
+}

--- a/lib/src/cli/flutterpi_command.dart
+++ b/lib/src/cli/flutterpi_command.dart
@@ -109,6 +109,16 @@ mixin FlutterpiCommandMixin on FlutterCommand {
     );
   }
 
+  void usesDummyDisplayArg() {
+    argParser.addOption(
+      'dummy-display',
+      help: 'Simulate a dummy display (if no real display is connected). '
+          'Optionally specify the size in pixels of the dummy display.',
+      valueHelp: 'width x height',
+      defaultsTo: '',
+    );
+  }
+
   (int, int)? get displaySize {
     final size = stringArg('display-size');
     if (size == null) {
@@ -129,6 +139,37 @@ mixin FlutterpiCommandMixin on FlutterCommand {
         'Invalid --display-size: Expected both dimensions to be integers.',
       );
     }
+  }
+
+  (int, int)? get dummyDisplaySize {
+    final size = stringArg('dummy-display');
+    if (size == null || size == '') {
+      return null;
+    }
+
+    final parts = size.split('x');
+    if (parts.length != 2) {
+      usageException(
+        'Invalid --dummy-display: Expected two dimensions separated by "x".',
+      );
+    }
+
+    try {
+      return (int.parse(parts[0].trim()), int.parse(parts[1].trim()));
+    } on FormatException {
+      usageException(
+        'Invalid --dummy-display: Expected both dimensions to be integers.',
+      );
+    }
+  }
+
+  bool get useDummyDisplay {
+    final dummyDisplay = stringArg('dummy-display');
+    if (dummyDisplay != null) {
+      return true;
+    }
+
+    return false;
   }
 
   double? get pixelRatio {

--- a/lib/src/cli/flutterpi_command.dart
+++ b/lib/src/cli/flutterpi_command.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutterpi_tool/src/application_package_factory.dart';

--- a/lib/src/cli/flutterpi_command.dart
+++ b/lib/src/cli/flutterpi_command.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutterpi_tool/src/application_package_factory.dart';
@@ -110,12 +111,17 @@ mixin FlutterpiCommandMixin on FlutterCommand {
   }
 
   void usesDummyDisplayArg() {
-    argParser.addOption(
+    argParser.addFlag(
       'dummy-display',
-      help: 'Simulate a dummy display (if no real display is connected). '
-          'Optionally specify the size in pixels of the dummy display.',
+      help:
+          'Simulate a dummy display. (Useful if no real display is connected)',
+    );
+
+    argParser.addOption(
+      'dummy-display-size',
+      help:
+          'Simulate a dummy display with a specific size in physical pixels. (Useful if no real display is connected)',
       valueHelp: 'width x height',
-      defaultsTo: '',
     );
   }
 
@@ -142,15 +148,15 @@ mixin FlutterpiCommandMixin on FlutterCommand {
   }
 
   (int, int)? get dummyDisplaySize {
-    final size = stringArg('dummy-display');
-    if (size == null || size == '') {
+    final size = stringArg('dummy-display-size');
+    if (size == null) {
       return null;
     }
 
     final parts = size.split('x');
     if (parts.length != 2) {
       usageException(
-        'Invalid --dummy-display: Expected two dimensions separated by "x".',
+        'Invalid --dummy-display-size: Expected two dimensions separated by "x".',
       );
     }
 
@@ -158,14 +164,15 @@ mixin FlutterpiCommandMixin on FlutterCommand {
       return (int.parse(parts[0].trim()), int.parse(parts[1].trim()));
     } on FormatException {
       usageException(
-        'Invalid --dummy-display: Expected both dimensions to be integers.',
+        'Invalid --dummy-display-size: Expected both dimensions to be integers.',
       );
     }
   }
 
   bool get useDummyDisplay {
-    final dummyDisplay = stringArg('dummy-display');
-    if (dummyDisplay != null) {
+    final dummyDisplay = boolArg('dummy-display');
+    final dummyDisplaySize = stringArg('dummy-display-size');
+    if (dummyDisplay || dummyDisplaySize != null) {
       return true;
     }
 

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -9,6 +9,8 @@ class DeviceConfigEntry {
     required this.remoteInstallPath,
     this.displaySizeMillimeters,
     this.devicePixelRatio,
+    this.useDummyDisplay,
+    this.dummyDisplaySize,
   });
 
   final String id;
@@ -17,6 +19,8 @@ class DeviceConfigEntry {
   final String? remoteInstallPath;
   final (int, int)? displaySizeMillimeters;
   final double? devicePixelRatio;
+  final bool? useDummyDisplay;
+  final (int, int)? dummyDisplaySize;
 
   static DeviceConfigEntry fromMap(Map<String, dynamic> map) {
     return DeviceConfigEntry(
@@ -29,6 +33,11 @@ class DeviceConfigEntry {
         _ => null,
       },
       devicePixelRatio: (map['devicePixelRatio'] as num?)?.toDouble(),
+      useDummyDisplay: map['useDummyDisplay'] as bool?,
+      dummyDisplaySize: switch (map['dummyDisplaySize']) {
+        [num width, num height] => (width.round(), height.round()),
+        _ => null,
+      },
     );
   }
 
@@ -42,6 +51,10 @@ class DeviceConfigEntry {
         'displaySizeMillimeters': [width, height],
       if (devicePixelRatio case int devicePixelRatio)
         'devicePixelRatio': devicePixelRatio,
+      if (useDummyDisplay case bool useDummyDisplay)
+        'useDummyDisplay': useDummyDisplay,
+      if (dummyDisplaySize case (final width, final height))
+        'dummyDisplaySize': [width, height],
     };
   }
 
@@ -58,7 +71,9 @@ class DeviceConfigEntry {
         sshRemote == otherEntry.sshRemote &&
         remoteInstallPath == otherEntry.remoteInstallPath &&
         displaySizeMillimeters == otherEntry.displaySizeMillimeters &&
-        devicePixelRatio == otherEntry.devicePixelRatio;
+        devicePixelRatio == otherEntry.devicePixelRatio &&
+        useDummyDisplay == otherEntry.useDummyDisplay &&
+        dummyDisplaySize == otherEntry.dummyDisplaySize;
   }
 
   @override
@@ -69,6 +84,8 @@ class DeviceConfigEntry {
         remoteInstallPath,
         displaySizeMillimeters,
         devicePixelRatio,
+        useDummyDisplay,
+        dummyDisplaySize,
       );
 }
 

--- a/lib/src/devices/flutterpi_ssh/device.dart
+++ b/lib/src/devices/flutterpi_ssh/device.dart
@@ -104,6 +104,18 @@ class _RunningApp {
   }
 }
 
+class FlutterpiArgs {
+  const FlutterpiArgs({
+    this.explicitDisplaySizeMillimeters,
+    this.useDummyDisplay = false,
+    this.dummyDisplaySize,
+  });
+
+  final (int, int)? explicitDisplaySizeMillimeters;
+  final bool useDummyDisplay;
+  final (int, int)? dummyDisplaySize;
+}
+
 class FlutterpiSshDevice extends Device {
   FlutterpiSshDevice({
     required String id,
@@ -113,8 +125,7 @@ class FlutterpiSshDevice extends Device {
     required this.logger,
     required this.os,
     required this.cache,
-    this.explicitDevicePixelRatio,
-    this.explicitDisplaySizeMillimeters,
+    this.args = const FlutterpiArgs(),
   })  : remoteInstallPath = remoteInstallPath ?? '/tmp/',
         super(
           id,
@@ -129,13 +140,11 @@ class FlutterpiSshDevice extends Device {
   final Logger logger;
   final FlutterpiCache cache;
   final MoreOperatingSystemUtils os;
+  final FlutterpiArgs args;
 
   final runningApps = <String, _RunningApp>{};
   final logReaders = <String, CustomDeviceLogReader>{};
   final globalLogReader = CustomDeviceLogReader('FlutterPi');
-
-  final double? explicitDevicePixelRatio;
-  final (int, int)? explicitDisplaySizeMillimeters;
 
   String _getRemoteInstallPath(FlutterpiAppBundle bundle) {
     return path.posix.join(remoteInstallPath, bundle.id);
@@ -342,10 +351,14 @@ class FlutterpiSshDevice extends Device {
 
     return [
       flutterpiExe,
-      if (explicitDisplaySizeMillimeters case (final width, final height)) ...[
+      if (args.explicitDisplaySizeMillimeters
+          case (final width, final height)) ...[
         '--dimensions',
         '$width,$height',
       ],
+      if (args.useDummyDisplay) '--dummy-display',
+      if (args.dummyDisplaySize case (final width, final height))
+        '--dummy-display-size=$width,$height',
       if (runtimeModeArg != null) runtimeModeArg,
       bundlePath,
       ...engineArgs,

--- a/lib/src/devices/flutterpi_ssh/device_discovery.dart
+++ b/lib/src/devices/flutterpi_ssh/device_discovery.dart
@@ -45,8 +45,11 @@ class FlutterpiSshDeviceDiscovery extends PollingDeviceDiscovery {
       logger: logger,
       cache: cache,
       os: os,
-      explicitDisplaySizeMillimeters: configEntry.displaySizeMillimeters,
-      explicitDevicePixelRatio: null,
+      args: FlutterpiArgs(
+        explicitDisplaySizeMillimeters: configEntry.displaySizeMillimeters,
+        useDummyDisplay: configEntry.useDummyDisplay ?? false,
+        dummyDisplaySize: configEntry.dummyDisplaySize,
+      ),
     );
   }
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -8,6 +8,7 @@ import 'package:flutterpi_tool/src/cli/command_runner.dart';
 import 'package:flutterpi_tool/src/cli/commands/devices.dart';
 import 'package:flutterpi_tool/src/cli/commands/precache.dart';
 import 'package:flutterpi_tool/src/cli/commands/run.dart';
+import 'package:flutterpi_tool/src/cli/commands/test.dart';
 
 Future<void> main(List<String> args) async {
   final verbose =
@@ -29,6 +30,7 @@ Future<void> main(List<String> args) async {
   runner.addCommand(PrecacheCommand(verboseHelp: verboseHelp));
   runner.addCommand(DevicesCommand(verboseHelp: verboseHelp));
   runner.addCommand(RunCommand());
+  runner.addCommand(TestCommand());
 
   runner.argParser
     ..addSeparator('Other options')

--- a/lib/src/fltool/common.dart
+++ b/lib/src/fltool/common.dart
@@ -29,4 +29,6 @@ export 'package:flutter_tools/src/build_system/build_targets.dart';
 export 'package:flutter_tools/src/isolated/build_targets.dart';
 export 'package:flutter_tools/src/flutter_application_package.dart';
 export 'package:flutter_tools/src/base/terminal.dart';
+export 'package:flutter_tools/src/commands/run.dart';
+export 'package:flutter_tools/src/commands/test.dart';
 export 'package:flutter_tools/src/commands/devices.dart' hide DevicesCommand;


### PR DESCRIPTION
- add `flutterpi_tool test` subcommand
- enable running tests on remote devices using `flutterpi_tool test -d`
- add `--dummy-display` flag to `flutterpi_tool devices add` subcommand
  - also has an optional `widthxheight` arg, e.g. both of these are valid:
    - `flutterpi_tool devices add x --dummy-display`
    - `flutterpi_tool devices add x --dummy-display=800x480`
  - will simulate a display, if no real display is attached
- also fix some build options not being passed down completely

(in combination, that makes it possible to run integration tests on devices with no display attached.)