### PR TITLE
Fix flutter-pi artifacts not being passed into the build process

### DIFF
--- a/lib/src/cli/commands/build.dart
+++ b/lib/src/cli/commands/build.dart
@@ -176,6 +176,7 @@ class BuildCommand extends FlutterpiCommand {
       target: targetPlatform,
       buildInfo: buildInfo,
       mainPath: targetFile,
+      artifacts: artifacts,
 
       // for `--debug-unoptimized` build mode
       unoptimized: flavor.unoptimized,


### PR DESCRIPTION
The flutter-pi artifacts were not being passed in through the build context, causing lots of errors relating to file locations

Fixes #64