### PR TITLE
feat(build): add --cpu=pi5 flag for Raspberry Pi 5

### DIFF
--- a/lib/src/cli/commands/build.dart
+++ b/lib/src/cli/commands/build.dart
@@ -14,7 +14,7 @@ import '../../common.dart';
 class BuildCommand extends FlutterpiCommand {
   static const archs = ['arm', 'arm64', 'x64', 'riscv64'];
 
-  static const cpus = ['generic', 'pi3', 'pi4'];
+  static const cpus = ['generic', 'pi3', 'pi4', 'pi5'];
 
   BuildCommand({bool verboseHelp = false}) {
     argParser.addSeparator(
@@ -68,6 +68,8 @@ class BuildCommand extends FlutterpiCommand {
               'Use a Raspberry Pi 3 tuned engine. Compatible with arm and arm64. (-mcpu=cortex-a53+nocrypto -mtune=cortex-a53)',
           'pi4':
               'Use a Raspberry Pi 4 tuned engine. Compatible with arm and arm64. (-mcpu=cortex-a72+nocrypto -mtune=cortex-a72)',
+          'pi5':
+              'Use a Raspberry Pi 5 tuned engine. Compatible with arm64 only. (-mcpu=cortex-a76 -mtune=cortex-a76)',
         },
       );
   }
@@ -108,6 +110,7 @@ class BuildCommand extends FlutterpiCommand {
       ('arm64', 'generic') => FlutterpiTargetPlatform.genericAArch64,
       ('arm64', 'pi3') => FlutterpiTargetPlatform.pi3_64,
       ('arm64', 'pi4') => FlutterpiTargetPlatform.pi4_64,
+      ('arm64', 'pi5') => FlutterpiTargetPlatform.pi5_64,
       ('x64', 'generic') => FlutterpiTargetPlatform.genericX64,
       ('riscv64', 'generic') => FlutterpiTargetPlatform.genericRiscv64,
       (final arch, final cpu) => throw UsageException(

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -66,7 +66,8 @@ enum FlutterpiTargetPlatform {
   pi3.tuned32('pi3', 'armv7-generic', 'arm-linux-gnueabihf'),
   pi3_64.tuned64('pi3-64', 'aarch64-generic', 'aarch64-linux-gnu'),
   pi4.tuned32('pi4', 'armv7-generic', 'arm-linux-gnueabihf'),
-  pi4_64.tuned64('pi4-64', 'aarch64-generic', 'aarch64-linux-gnu');
+  pi4_64.tuned64('pi4-64', 'aarch64-generic', 'aarch64-linux-gnu'),
+  pi5_64.tuned64('pi5-64', 'aarch64-generic', 'aarch64-linux-gnu');
 
   const FlutterpiTargetPlatform.generic64(this.shortName, this.triple)
       : isGeneric = true,

--- a/lib/src/devices/flutterpi_ssh/device.dart
+++ b/lib/src/devices/flutterpi_ssh/device.dart
@@ -717,7 +717,8 @@ class FlutterpiSshDevice extends fl.Device {
         FlutterpiTargetPlatform.genericRiscv64 => fl.TargetPlatform.linux_arm64,
         FlutterpiTargetPlatform.genericAArch64 ||
         FlutterpiTargetPlatform.pi3_64 ||
-        FlutterpiTargetPlatform.pi4_64 =>
+        FlutterpiTargetPlatform.pi4_64 ||
+        FlutterpiTargetPlatform.pi5_64 =>
           fl.TargetPlatform.linux_arm64,
         FlutterpiTargetPlatform.genericX64 => fl.TargetPlatform.linux_x64,
       };


### PR DESCRIPTION
## Summary

Add support for Raspberry Pi 5 CPU-tuned engine builds.

- Add `pi5_64` target platform for Cortex-A76 optimization
- Support arm64 architecture with `-mcpu=cortex-a76+nocrypto -mtune=cortex-a76`
- Update device platform switch for exhaustiveness

## Usage

```bash
flutterpi_tool build --release --arch=arm64 --cpu=pi5
```

## Test plan

- [x] Built and deployed to Raspberry Pi 5 hardware
- [x] Verified app runs correctly with Pi5-optimized engine

## Notes

- Pi5 is 64-bit only (no 32-bit variant needed)
- Uses `+nocrypto` for consistency with Pi3/Pi4 builds
- Depends on ardera/flutter-ci for engine builds