### PR TITLE
feat(build): add CLI options for custom engine artifact sources

### DIFF
--- a/lib/src/cli/commands/build.dart
+++ b/lib/src/cli/commands/build.dart
@@ -38,6 +38,7 @@ class BuildCommand extends FlutterpiCommand {
     usesTargetOption();
     usesLocalFlutterpiExecutableArg(verboseHelp: verboseHelp);
     usesFilesystemLayoutArg(verboseHelp: verboseHelp);
+    usesGithubArtifactsOptions(verboseHelp: verboseHelp);
 
     argParser
       ..addSeparator('Target options')

--- a/lib/src/cli/flutterpi_command.dart
+++ b/lib/src/cli/flutterpi_command.dart
@@ -273,6 +273,40 @@ mixin FlutterpiCommandMixin on fl.FlutterCommand {
     );
   }
 
+  void usesGithubArtifactsOptions({bool verboseHelp = false}) {
+    argParser.addOption(
+      'github-artifacts-repo',
+      help:
+          'Use a custom GitHub repository for engine artifacts instead of ardera/flutter-ci.',
+      valueHelp: 'owner/repo',
+      hide: !verboseHelp,
+    );
+
+    argParser.addOption(
+      'github-artifacts-runid',
+      help:
+          'Download engine artifacts from a specific GitHub Actions workflow run instead of releases.',
+      valueHelp: 'run-id',
+      hide: !verboseHelp,
+    );
+
+    argParser.addOption(
+      'github-artifacts-engine-version',
+      help:
+          'Specify the engine version available in the workflow run artifacts.',
+      valueHelp: 'engine-hash',
+      hide: !verboseHelp,
+    );
+
+    argParser.addOption(
+      'github-artifacts-auth-token',
+      help:
+          'GitHub authentication token for accessing artifacts. Can also be set via GITHUB_TOKEN environment variable.',
+      valueHelp: 'token',
+      hide: !verboseHelp,
+    );
+  }
+
   bool getIncludeDebugSymbols() {
     return boolArg('debug-symbols');
   }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -15,6 +15,7 @@ import 'package:flutterpi_tool/src/fltool/common.dart' as fl;
 import 'package:flutterpi_tool/src/fltool/globals.dart' as globals;
 import 'package:flutterpi_tool/src/github.dart';
 import 'package:flutterpi_tool/src/more_os_utils.dart';
+import 'package:github/github.dart' as gh;
 
 // ignore: implementation_imports
 import 'package:flutter_tools/src/context_runner.dart' as fl;
@@ -22,13 +23,30 @@ import 'package:flutter_tools/src/context_runner.dart' as fl;
 Future<V> runInContext<V>(
   FutureOr<V> Function() fn, {
   bool verbose = false,
+  String? githubArtifactsRepo,
+  String? githubArtifactsRunId,
+  String? githubArtifactsEngineVersion,
+  String? githubArtifactsAuthToken,
 }) async {
   return await fl.runInContext(
     fn,
     overrides: {
       Analytics: () => const NoOpAnalytics(),
       fl.TemplateRenderer: () => const fl.MustacheTemplateRenderer(),
-      fl.Cache: () => FlutterpiCache(
+      fl.Cache: () {
+        // Check environment variable for token if not provided
+        final token = githubArtifactsAuthToken ??
+            globals.platform.environment['GITHUB_TOKEN'];
+
+        final github = MyGithub.caching(
+          httpClient: http.IOClient(
+            globals.httpClientFactory?.call() ?? io.HttpClient(),
+          ),
+          auth: token != null ? gh.Authentication.bearerToken(token) : null,
+        );
+
+        if (githubArtifactsRunId != null) {
+          return FlutterpiCache.fromWorkflow(
             hooks: globals.shutdownHooks,
             logger: globals.logger,
             fileSystem: globals.fs,
@@ -36,12 +54,29 @@ Future<V> runInContext<V>(
             osUtils: globals.os as MoreOperatingSystemUtils,
             projectFactory: globals.projectFactory,
             processManager: globals.processManager,
-            github: MyGithub.caching(
-              httpClient: http.IOClient(
-                globals.httpClientFactory?.call() ?? io.HttpClient(),
-              ),
-            ),
-          ),
+            repo: githubArtifactsRepo != null
+                ? gh.RepositorySlug.full(githubArtifactsRepo)
+                : null,
+            runId: githubArtifactsRunId,
+            availableEngineVersion: githubArtifactsEngineVersion,
+            github: github,
+          );
+        } else {
+          return FlutterpiCache(
+            hooks: globals.shutdownHooks,
+            logger: globals.logger,
+            fileSystem: globals.fs,
+            platform: globals.platform,
+            osUtils: globals.os as MoreOperatingSystemUtils,
+            projectFactory: globals.projectFactory,
+            processManager: globals.processManager,
+            repo: githubArtifactsRepo != null
+                ? gh.RepositorySlug.full(githubArtifactsRepo)
+                : null,
+            github: github,
+          );
+        }
+      },
       fl.OperatingSystemUtils: () => MoreOperatingSystemUtils(
             fileSystem: globals.fs,
             logger: globals.logger,

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -36,6 +36,20 @@ FlutterpiToolCommandRunner createFlutterpiCommandRunner({
   return runner;
 }
 
+// Helper to extract option value from args
+String? _extractOption(List<String> args, String optionName) {
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '--$optionName' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--$optionName=')) {
+      return arg.substring('--$optionName='.length);
+    }
+  }
+  return null;
+}
+
 Future<void> main(List<String> args) async {
   final verbose =
       args.contains('-v') || args.contains('--verbose') || args.contains('-vv');
@@ -49,6 +63,14 @@ Future<void> main(List<String> args) async {
       (args.isNotEmpty && args.first == 'help') ||
       (args.length == 1 && verbose);
   final verboseHelp = help && verbose;
+
+  // Parse github-artifacts options early (before context is set up)
+  final githubArtifactsRepo = _extractOption(args, 'github-artifacts-repo');
+  final githubArtifactsRunId = _extractOption(args, 'github-artifacts-runid');
+  final githubArtifactsEngineVersion =
+      _extractOption(args, 'github-artifacts-engine-version');
+  final githubArtifactsAuthToken =
+      _extractOption(args, 'github-artifacts-auth-token');
 
   final runner = createFlutterpiCommandRunner(verboseHelp: verboseHelp);
 
@@ -86,5 +108,9 @@ Future<void> main(List<String> args) async {
       }
     },
     verbose: verbose,
+    githubArtifactsRepo: githubArtifactsRepo,
+    githubArtifactsRunId: githubArtifactsRunId,
+    githubArtifactsEngineVersion: githubArtifactsEngineVersion,
+    githubArtifactsAuthToken: githubArtifactsAuthToken,
   );
 }


### PR DESCRIPTION
## Summary

Add CLI options to download engine artifacts from custom GitHub repositories and workflow runs, enabling testing of custom engine builds before they are officially released.

### New options (hidden by default, shown with `--verbose`)

- `--github-artifacts-repo=<owner/repo>` - Use a custom GitHub repository for engine artifacts
- `--github-artifacts-runid=<run-id>` - Download from a specific GitHub Actions workflow run
- `--github-artifacts-engine-version=<hash>` - Specify the engine version in the workflow artifacts
- `--github-artifacts-auth-token=<token>` - GitHub authentication token (also reads `GITHUB_TOKEN` env)

## Use cases

- Testing engine builds from forks before merging upstream
- Using custom engine builds for development/debugging
- Downloading artifacts from specific workflow runs

## Example

```bash
# Test Pi5 engine from a fork's workflow run
export GITHUB_TOKEN=$(gh auth token)
flutterpi_tool build --release --arch=arm64 --cpu=pi5 \
  --github-artifacts-repo=myuser/flutter-ci \
  --github-artifacts-runid=12345678
```

## Test plan

- [x] Tested downloading artifacts from workflow run
- [x] Verified GITHUB_TOKEN authentication works
- [x] Built and deployed app with custom engine artifacts