### PR TITLE
Fix pollingGetDevices signature to match Flutter 3.41.x

### DIFF
--- a/lib/src/devices/flutterpi_ssh/device_discovery.dart
+++ b/lib/src/devices/flutterpi_ssh/device_discovery.dart
@@ -53,7 +53,7 @@ class FlutterpiSshDeviceDiscovery extends PollingDeviceDiscovery {
   }
 
   @override
-  Future<List<Device>> pollingGetDevices({Duration? timeout}) async {
+  Future<List<Device>> pollingGetDevices({Duration? timeout, bool forWirelessDiscovery = false}) async {
     timeout ??= Duration(seconds: 5);
 
     final entries = config.getDevices();


### PR DESCRIPTION
Add missing `forWirelessDiscovery` named parameter to `FlutterpiSshDeviceDiscovery.pollingGetDevices` to match the updated `PollingDeviceDiscovery` base class in Flutter >= 3.41.1.

Fixes #87