### PR TITLE
Modify pollingGetDevices to include wireless discovery

### DIFF
--- a/lib/src/devices/flutterpi_ssh/device_discovery.dart
+++ b/lib/src/devices/flutterpi_ssh/device_discovery.dart
@@ -53,7 +53,7 @@ class FlutterpiSshDeviceDiscovery extends PollingDeviceDiscovery {
   }
 
   @override
-  Future<List<Device>> pollingGetDevices({Duration? timeout}) async {
+  Future<List<Device>> pollingGetDevices({Duration? timeout, bool forWirelessDiscovery = false}) async {
     timeout ??= Duration(seconds: 5);
 
     final entries = config.getDevices();


### PR DESCRIPTION
Added 'forWirelessDiscovery' parameter to pollingGetDevices method to make it compatible with newer version of flutter