### PR TITLE
[codex] Expose workflow artifact flags on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,13 @@ Installing app on device...
 ```
 $ flutterpi_tool run -d pi5 --profile
 ```
+
+### 7. Building with artifacts pinned to a specific GitHub Actions run
+```console
+$ flutterpi_tool build --release \
+    --github-artifacts-runid=23382732417 \
+    --github-artifacts-engine-version=052f31d115eceda8cbff1b3481fcde4330c4ae12
+```
+
+This is useful when you want `build` to use workflow artifacts from a specific
+run instead of the default release-based artifact lookup.

--- a/lib/src/cli/commands/build.dart
+++ b/lib/src/cli/commands/build.dart
@@ -37,6 +37,7 @@ class BuildCommand extends FlutterpiCommand {
     usesDartDefineOption();
     usesTargetOption();
     usesLocalFlutterpiExecutableArg(verboseHelp: verboseHelp);
+    usesGithubWorkflowArtifactsArgs(verboseHelp: verboseHelp);
     usesFilesystemLayoutArg(verboseHelp: verboseHelp);
 
     argParser

--- a/lib/src/cli/flutterpi_command.dart
+++ b/lib/src/cli/flutterpi_command.dart
@@ -135,6 +135,38 @@ mixin FlutterpiCommandMixin on fl.FlutterCommand {
     );
   }
 
+  void usesGithubWorkflowArtifactsArgs({bool verboseHelp = false}) {
+    argParser
+      ..addOption(
+        'github-artifacts-repo',
+        help:
+            'Use workflow artifacts from the specified GitHub repository instead of release artifacts.',
+        valueHelp: 'owner/name',
+        hide: !verboseHelp,
+      )
+      ..addOption(
+        'github-artifacts-runid',
+        help:
+            'Use workflow artifacts from the specified GitHub Actions run id.',
+        valueHelp: 'run id',
+        hide: !verboseHelp,
+      )
+      ..addOption(
+        'github-artifacts-engine-version',
+        help:
+            'Restrict workflow artifact lookup to the specified engine version.',
+        valueHelp: 'engine version',
+        hide: !verboseHelp,
+      )
+      ..addOption(
+        'github-artifacts-auth-token',
+        help:
+            'Use this GitHub token when querying private or rate-limited workflow artifacts.',
+        valueHelp: 'token',
+        hide: !verboseHelp,
+      );
+  }
+
   void usesRotationArg() {
     argParser.addOption(
       'rotation',

--- a/test/commands/build_test.dart
+++ b/test/commands/build_test.dart
@@ -671,4 +671,45 @@ void main() {
       reason: "Expected BuildSystem.build to be called",
     );
   });
+
+  test('accepts github workflow artifact flags', () async {
+    var buildWasCalled = false;
+    appBuilder.buildFn = ({
+      required FlutterpiHostPlatform host,
+      required FlutterpiTargetPlatform target,
+      required fl.BuildInfo buildInfo,
+      required FilesystemLayout fsLayout,
+      fl.FlutterProject? project,
+      FlutterpiArtifacts? artifacts,
+      String? mainPath,
+      String manifestPath = fl.defaultManifestPath,
+      String? applicationKernelFilePath,
+      String? depfilePath,
+      Directory? outDir,
+      bool unoptimized = false,
+      bool includeDebugSymbols = false,
+      bool forceBundleFlutterpi = false,
+    }) async {
+      buildWasCalled = true;
+    };
+
+    await _runInTestContext(() async {
+      await runner.run([
+        'build',
+        '--release',
+        '--arch',
+        'arm64',
+        '--cpu',
+        'generic',
+        '--github-artifacts-runid=23382732417',
+        '--github-artifacts-engine-version=052f31d115eceda8cbff1b3481fcde4330c4ae12',
+      ]);
+    });
+
+    expect(
+      buildWasCalled,
+      isTrue,
+      reason: "Expected BuildSystem.build to be called",
+    );
+  });
 }


### PR DESCRIPTION
This wires the existing workflow-artifact path through to `flutterpi_tool build`.

The cache layer already knows how to resolve artifacts from a specific GitHub Actions run via the `github-artifacts-*` settings, but the `build` command never exposed those options on the CLI. In practice that meant issue #89 was real: the plumbing existed, but there was no way to reach it from `build`.

This change keeps the scope narrow:
- add the `github-artifacts-repo`, `github-artifacts-runid`, `github-artifacts-engine-version`, and `github-artifacts-auth-token` options to `flutterpi_tool build`
- add a regression test covering a `build` invocation that pins workflow artifacts

I did not extend this into an offline or Yocto/meta-flutter workflow. This patch is only about making the existing workflow-backed artifact selection usable from `build`.

Validation was split by environment. On Windows I ran the targeted `build` command tests plus `dart analyze`. For the full suite, I verified the branch in a real WSL/Linux Flutter environment and `dart test` passes there end-to-end. I am calling that out because the current Windows runtime still has unrelated path-separator expectation failures in `test/app_builder_test.dart`, and this patch does not change that behavior.
